### PR TITLE
length (Time) should be equal to nrow(newdata2)

### DIFF
--- a/R/prederrJM.mvJMbayes.R
+++ b/R/prederrJM.mvJMbayes.R
@@ -44,8 +44,7 @@ prederrJM.mvJMbayes <- function (object, newdata, Tstart, Thoriz, lossFun = c("s
         Time2 <- SurvT[, "time2"]
         Time <- Time1
         Time[Time2 != 1] <- Time2[Time2 != 1]
-        Time <- Time[!duplicated(id2)]
-        event <- SurvT[!duplicated(id2), "status"]
+        event <- SurvT[, "status"]
     } else {
         Time <- SurvT[, 1]
         event <- SurvT[, 2]


### PR DESCRIPTION
Changes are to be made for interval censored data. The time of Time vector should be equal to the nrows in the newdata2 dataframe. This is required in order to correctly select alive,dead and censored patients.